### PR TITLE
Better support for persistent volumes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM	alpine:3.4
 MAINTAINER Carsten Ringe <carsten@kopis.de>
 
 EXPOSE	80
-VOLUME	["/dokuwiki-data", "/dokuwiki-conf"]
+VOLUME	["/dokuwiki-data", "/dokuwiki-conf", "/dokuwiki-plugins"]
 
 RUN	apk update && apk add -U php5-cli php5-mysqli php5-ctype php5-xml php5-gd php5-zlib php5-openssl php5-curl php5-opcache php5-json php5-ldap curl
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -14,6 +14,9 @@ curl -Lqo /dokuwiki.tar.gz http://download.dokuwiki.org/src/dokuwiki/$VERSION.tg
 
 # move directories out of web root
 mv $BASE_DIR/data/* /dokuwiki-data/
+mv $BASE_DIR/lib/plugins/* /dokuwiki-plugins/
+rm -rf $BASE_DIR/lib/plugins/
+ln -s /dokuwiki-plugins $BASE_DIR/lib/plugins
 
 #do not replace the configs if we find existing ones
 if [ ! -f "/dokuwiki-conf/local.php" ]; then

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -14,14 +14,20 @@ curl -Lqo /dokuwiki.tar.gz http://download.dokuwiki.org/src/dokuwiki/$VERSION.tg
 
 # move directories out of web root
 mv $BASE_DIR/data/* /dokuwiki-data/
-mv $BASE_DIR/conf/* /dokuwiki-conf/
 
+#do not replace the configs if we find existing ones
+if [ ! -f "/dokuwiki-conf/local.php" ]; then
+ echo "creating initial config ...";
+ mv $BASE_DIR/conf/* /dokuwiki-conf/
+fi
 # create preload.php
 cat << EOF > $BASE_DIR/inc/preload.php
 <?php
 define('DOKU_CONF','/dokuwiki-conf/');
 EOF
 
+#only change the config if we don't find existing ones
+if [ ! -f "/dokuwiki-conf/local.php" ]; then
 # add savedir option to local configuration
 cat << EOF > /dokuwiki-conf/local.php
 <?php
@@ -40,7 +46,7 @@ EOF
 cat << EOF > /dokuwiki-conf/users.auth.php
 admin:21232f297a57a5a743894a0e4a801fc3:admin:admin@localhost:admin,users,devel,support
 EOF
-
+fi
 # run dokuwiki
 php -S 0.0.0.0:80 -t $BASE_DIR/
 


### PR DESCRIPTION
If persistent docker volumes are used e.g. host bindings it is not necessary to always completely overwrite the config as it might have been changed through the dokuwiki web interface. Also added /dokuwiki-plugins as a separate volume to enable persistent plugins throughout container restarts.